### PR TITLE
Fix 'main' field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "unicode-bidirectional",
   "version": "2.0.5",
   "description": "An implementation of Unicode 9.0.0 Bidirectional Algorithm",
-  "main": "dist/unicode-bidirectional.js",
+  "main": "dist/unicode.bidirectional.js",
   "module": "src/main.js",
   "es6": "src/main.js",
   "scripts": {


### PR DESCRIPTION
The webpack build produces `dist/unicode.bidirectional.js` but package.json refered to `dist/unicode-bidirectional.js`.